### PR TITLE
Dynamically tokenize request

### DIFF
--- a/simple-web-server/src/http_tokenizer.rs
+++ b/simple-web-server/src/http_tokenizer.rs
@@ -1,6 +1,5 @@
 use std::borrow::Cow;
 
-// Basic version
 // TODO: maybe add user_agent, content_length, connection in the future
 pub struct HttpReq {
     pub method: String,
@@ -9,9 +8,7 @@ pub struct HttpReq {
      body: String,
 }
 
-// Early version, currently only looks for GET,POST,PUT,DELETE
 pub fn tokenize(req: Cow<'_, str>) -> HttpReq {
-
 
     // Initialize an instance of the HttpReq struct with some default values to keep the compiler happy.
     let mut t: HttpReq = HttpReq {
@@ -22,14 +19,11 @@ pub fn tokenize(req: Cow<'_, str>) -> HttpReq {
     };
 
     for (index, line_val) in req.lines().enumerate() {
-
-
         // Because the method doesn't follow a Key: val structure, we'll count our blessings
         // that the spec defines it as the very first thing in the request and match it first.
         if index == 0 {
             t.method = get_first_word(line_val);
         }
-
 
         // All other values in the headers are following a Key: Val structure,
         // so we'll break these apart into a normalised key (snake_cased) and a value.

--- a/simple-web-server/src/http_tokenizer.rs
+++ b/simple-web-server/src/http_tokenizer.rs
@@ -1,0 +1,71 @@
+use std::borrow::Cow;
+
+// Basic version
+// TODO: maybe add user_agent, content_length, connection in the future
+pub struct HttpReq {
+    pub method: String,
+     host: String,
+     content_type: String,
+     body: String,
+}
+
+// Early version, currently only looks for GET,POST,PUT,DELETE
+pub fn tokenize(req: Cow<'_, str>) -> HttpReq {
+
+
+    // Initialize an instance of the HttpReq struct with some default values to keep the compiler happy.
+    let mut t: HttpReq = HttpReq {
+        method: "UNKNOWN".to_string(),
+        host: "UNKNOWN".to_string(),
+        content_type: "UNKNOWN".to_string(),
+        body: "UNKNOWN".to_string()
+    };
+
+    for (index, line_val) in req.lines().enumerate() {
+
+
+        // Because the method doesn't follow a Key: val structure, we'll count our blessings
+        // that the spec defines it as the very first thing in the request and match it first.
+        if index == 0 {
+            t.method = get_first_word(line_val);
+        }
+
+
+        // All other values in the headers are following a Key: Val structure,
+        // so we'll break these apart into a normalised key (snake_cased) and a value.
+        // For each key we derive from the request headers, we'll run a match.
+        // If the normalized_key is a match to any of the fields in the struct we'll set
+        // the value of that field to the value we've derived from the request.
+        let normalized_key = get_first_word(line_val)
+            .to_lowercase()
+            .replace("-", "_")
+            .replace(":", "");
+
+        let value = get_key_value(line_val);
+
+        // @todo - Refactor into a less disgusting mess, couldn't get this working with `match`
+        if normalized_key == String::from("host") {
+            t.host = value;
+        } else if normalized_key == String::from("content_type") {
+            t.content_type = value;
+        } else if normalized_key == String::from("body") {
+            t.body = value;
+        }
+    }
+
+    return t;
+}
+
+fn get_first_word(line: &str) -> String {
+    return line.split_whitespace()
+        .next()
+        .unwrap_or("")
+        .to_string();
+}
+
+fn get_key_value(line: &str) -> String {
+    let mut split = line.split(": ");
+
+    split.next(); // Move the iterator along once...
+    return split.next().unwrap_or("").to_string(); // Move the iterator along again and return!
+}

--- a/simple-web-server/src/http_tokenizer.rs
+++ b/simple-web-server/src/http_tokenizer.rs
@@ -22,7 +22,7 @@ pub fn tokenize(req: Cow<'_, str>) -> HttpReq {
         // Because the method doesn't follow a Key: val structure, we'll count our blessings
         // that the spec defines it as the very first thing in the request and match it first.
         if index == 0 {
-            t.method = get_first_word(line_val);
+            t.method = get_key(line_val);
         }
 
         // All other values in the headers are following a Key: Val structure,
@@ -30,12 +30,12 @@ pub fn tokenize(req: Cow<'_, str>) -> HttpReq {
         // For each key we derive from the request headers, we'll run a match.
         // If the normalized_key is a match to any of the fields in the struct we'll set
         // the value of that field to the value we've derived from the request.
-        let normalized_key = get_first_word(line_val)
+        let normalized_key = get_key(line_val)
             .to_lowercase()
             .replace("-", "_")
             .replace(":", "");
 
-        let value = get_key_value(line_val);
+        let value = get_value(line_val);
 
         // @todo - Refactor into a less disgusting mess, couldn't get this working with `match`
         if normalized_key == String::from("host") {
@@ -50,14 +50,14 @@ pub fn tokenize(req: Cow<'_, str>) -> HttpReq {
     return t;
 }
 
-fn get_first_word(line: &str) -> String {
+fn get_key(line: &str) -> String {
     return line.split_whitespace()
         .next()
         .unwrap_or("")
         .to_string();
 }
 
-fn get_key_value(line: &str) -> String {
+fn get_value(line: &str) -> String {
     let mut split = line.split(": ");
 
     split.next(); // Move the iterator along once...

--- a/simple-web-server/src/main.rs
+++ b/simple-web-server/src/main.rs
@@ -2,7 +2,8 @@ use std::net::TcpListener;
 use std::net::TcpStream;
 use std::io::prelude::*;
 use std::io::{self};
-use std::borrow::Cow;
+
+mod http_tokenizer;
 
 fn main() {
 
@@ -44,9 +45,9 @@ fn handle_connection(mut stream: TcpStream) {
 
     // Prints a string of the HTTP request to Terminal
     let http_str = String::from_utf8_lossy(&buffer[..]);
-    println!("{}", http_str); // prints out http request TODO: remove this later
+//    println!("{}", http_str); // prints out http request TODO: remove this later
 
-    let token = tokenize_http_req(http_str);
+    let token = http_tokenizer::tokenize(http_str);
     println!("{}", token.method); // TODO: Remove this later
 
 
@@ -54,45 +55,4 @@ fn handle_connection(mut stream: TcpStream) {
 
     stream.write(response.as_bytes()).unwrap();
     stream.flush().unwrap();
-}
-
-// Basic version
-// TODO: maybe add user_agent, content_length, connection in the future
-struct HttpReq {
-    method: String,
-    // host: String,
-    // content_type: String,
-    // body: String,
-}
-
-// Early version, currently only looks for GET,POST,PUT,DELETE
-fn tokenize_http_req(req: Cow<'_, str>) -> HttpReq {
-
-    // splits string into newlines so it can be iterated over
-    let header = req.lines();
-    let mut method = String::new();
-
-    for line in header {
-        let words = line.split_whitespace();
-        for word in words {
-            if word == "GET" {
-                method = word.to_string();
-            }
-            else if word == "POST" {
-                method = word.to_string();
-            }
-            else if word == "PUT" {
-                method = word.to_string();
-            }
-            else if word == "DELETE" {
-                method = word.to_string();
-            }
-        }
-    }
-
-    let t = HttpReq {
-        method: method,
-    };
-
-    return t
 }


### PR DESCRIPTION
This PR dynamically tokenizes the values contained in the request headers into a struct. 
It also moves the tokenizer logic into a separate file which is referenced from `main.rs`